### PR TITLE
練習録とアフター録を月ごとに表示するように変更

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -193,37 +193,66 @@ def member_confirm():
 
 @app.route('/training/')
 def training():
-    per_page = 20
-    page_disp_msg = '{total}件中 {start}件 - {end}件'
-    page = request.args.get('page') or 1
-    page = max([1, int(page)])
     trainings = Training.query
-    keywords = request.args.get('keyword')
-    day_from = request.args.get('from')
-    day_until = request.args.get('until')
-    if keywords is not None:
-        for keyword in keywords.split(','):
-            keyword = keyword.replace(' ', '')
-            keyword = keyword.replace('　', '')
-            trainings = trainings.filter(Training.comment.contains(keyword))
-    if day_from is not None and day_from != "":
-        day_from = datetime.datetime.strptime(day_from, '%Y-%m-%d')
-        trainings = trainings.filter(Training.date >= day_from)
-    if day_until is not None and day_until != "":
-        day_until = datetime.datetime.strptime(day_until, '%Y-%m-%d')
-        trainings = trainings.filter(Training.date <= day_until)
     if request.args.get('submit') == "検索":
+        keywords = request.args.get('keyword')
+        day_from = request.args.get('from')
+        day_until = request.args.get('until')
+        if keywords is not None:
+            for keyword in keywords.split(','):
+                keyword = keyword.replace(' ', '')
+                keyword = keyword.replace('　', '')
+                trainings = trainings.filter(
+                    Training.comment.contains(keyword))
+        if day_from is not None and day_from != "":
+            day_from = datetime.datetime.strptime(day_from, '%Y-%m-%d')
+            trainings = trainings.filter(Training.date >= day_from)
+        if day_until is not None and day_until != "":
+            day_until = datetime.datetime.strptime(day_until, '%Y-%m-%d')
+            trainings = trainings.filter(Training.date <= day_until)
         count = trainings.count()
+        per_page = 20
+        page_disp_msg = '{total}件中 {start}件 - {end}件'
+        page = request.args.get('page') or 1
+        page = max([1, int(page)])
+        pagination = Pagination(
+            page=page,
+            total=count,
+            per_page=per_page,
+            css_framework='bootstrap4',
+            display_msg=page_disp_msg)
         if count > 0:
             flash('{}件ヒットしました'.format(count), 'info')
         else:
             flash('ヒットしませんでした', 'danger')
-    trainings = trainings.order_by(Training.date.desc())
-    pagination = Pagination(page=page, total=trainings.count(
-    ), per_page=per_page, css_framework='bootstrap4', display_msg=page_disp_msg)
-    return render_template('training.html', trainings=trainings.paginate(
-        page, per_page), pagination=pagination)
-    return render_template('training.html', pagination=trainings)
+        trainings = trainings.order_by(
+            Training.date.desc()).paginate(
+            page, per_page)
+        return render_template(
+            'training.html', trainings=trainings, pagination=pagination)
+    else:
+        now = datetime.date.today().replace(day=1)
+        day_from = now
+        if request.args.get('target'):
+            day_from = datetime.datetime.date(
+                datetime.datetime.strptime(
+                    request.args.get('target'), '%Y-%m'))
+        if day_from.month == 12:
+            day_until = datetime.date(day_from.year + 1, 1, day_from.day)
+        else:
+            day_until = datetime.date(
+                day_from.year, day_from.month + 1, day_from.day)
+        if day_from.month == 1:
+            previous = datetime.date(day_from.year - 1, 12, day_from.day)
+        else:
+            previous = datetime.date(
+                day_from.year, day_from.month - 1, day_from.day)
+        trainings = trainings.filter(
+            Training.date >= day_from).filter(
+            Training.date < day_until).order_by(
+            Training.date.desc()).all()
+        return render_template(
+            'training.html', trainings=trainings, now=now, target=day_from, previous=previous, next=day_until)
 
 
 @app.route('/training/edit', methods=['GET', 'POST'])
@@ -330,39 +359,66 @@ def training_confirm():
 
 @app.route('/after/')
 def after():
-    per_page = 20
-    page_disp_msg = '{total}件中 {start}件 - {end}件'
-    page = request.args.get('page') or 1
-    page = max([1, int(page)])
     afters = After.query
-    stage = request.args.get('stage')
-    keywords = request.args.get('keyword')
-    day_from = request.args.get('from')
-    day_until = request.args.get('until')
-    if stage is not None and stage != "":
-        afters = afters.filter(After.after_stage == int(stage))
-    if keywords is not None:
-        for keyword in keywords.split(','):
-            keyword = keyword.replace(' ', '')
-            keyword = keyword.replace('　', '')
-            afters = afters.filter(After.comment.contains(keyword))
-    if day_from is not None and day_from != "":
-        day_from = datetime.datetime.strptime(day_from, '%Y-%m-%d')
-        afters = afters.filter(After.date >= day_from)
-    if day_until is not None and day_until != "":
-        day_until = datetime.datetime.strptime(day_until, '%Y-%m-%d')
-        afters = afters.filter(After.date <= day_until)
     if request.args.get('submit') == "検索":
+        stage = request.args.get('stage')
+        keywords = request.args.get('keyword')
+        day_from = request.args.get('from')
+        day_until = request.args.get('until')
+        if stage is not None and stage != "":
+            afters = afters.filter(After.after_stage == int(stage))
+        if keywords is not None:
+            for keyword in keywords.split(','):
+                keyword = keyword.replace(' ', '')
+                keyword = keyword.replace('　', '')
+                afters = afters.filter(After.comment.contains(keyword))
+        if day_from is not None and day_from != "":
+            day_from = datetime.datetime.strptime(day_from, '%Y-%m-%d')
+            afters = afters.filter(After.date >= day_from)
+        if day_until is not None and day_until != "":
+            day_until = datetime.datetime.strptime(day_until, '%Y-%m-%d')
+            afters = afters.filter(After.date <= day_until)
         count = afters.count()
+        per_page = 20
+        page_disp_msg = '{total}件中 {start}件 - {end}件'
+        page = request.args.get('page') or 1
+        page = max([1, int(page)])
+        pagination = Pagination(
+            page=page,
+            total=count,
+            per_page=per_page,
+            css_framework='bootstrap4',
+            display_msg=page_disp_msg)
         if count > 0:
             flash('{}件ヒットしました'.format(count), 'info')
         else:
             flash('ヒットしませんでした', 'danger')
-    afters = afters.order_by(After.date.desc())
-    pagination = Pagination(page=page, total=afters.count(
-    ), per_page=per_page, css_framework='bootstrap4', display_msg=page_disp_msg)
-    return render_template('after.html', afters=afters.paginate(
-        page, per_page), pagination=pagination)
+        afters = afters.order_by(After.date.desc()).paginate(page, per_page)
+        return render_template(
+            'after.html', afters=afters, pagination=pagination)
+    else:
+        now = datetime.date.today().replace(day=1)
+        day_from = now
+        if request.args.get('target'):
+            day_from = datetime.datetime.date(
+                datetime.datetime.strptime(
+                    request.args.get('target'), '%Y-%m'))
+        if day_from.month == 12:
+            day_until = datetime.date(day_from.year + 1, 1, day_from.day)
+        else:
+            day_until = datetime.date(
+                day_from.year, day_from.month + 1, day_from.day)
+        if day_from.month == 1:
+            previous = datetime.date(day_from.year - 1, 12, day_from.day)
+        else:
+            previous = datetime.date(
+                day_from.year, day_from.month - 1, day_from.day)
+        afters = afters.filter(
+            After.date >= day_from).filter(
+            After.date < day_until).order_by(
+            After.date.desc()).all()
+        return render_template(
+            'after.html', afters=afters, now=now, target=day_from, previous=previous, next=day_until)
 
 
 @app.route('/after/edit', methods=['GET', 'POST'])

--- a/templates/after.html
+++ b/templates/after.html
@@ -31,21 +31,53 @@
           <a href="{{url_for('after_edit')}}" class="btn btn-primary">新規登録</a>
           {% endif %}
         </h1>
+        {% if request.args.get('submit') == '検索' %}
         <div class="text-center">
           {{ pagination.info }}
           {{ pagination.links }}
         </div>
+        {% else %}
+        <div class="bs-component">
+          <ul class="pager">
+            <li class="previous {{ "disabled" if target >= now}}"><a href="{{url_for('after', target=next.strftime('%Y-%m')) }}">&larr; 翌月</a></li>
+            <li>{{ target.year }}年{{ target.month }}月</li>
+            <li class="next {{ "disabled" if target.strftime('%Y-%m') <= "2001-08"}}"><a href="{{url_for('after', target=previous.strftime('%Y-%m')) }}" disa>前月 &rarr;</a></li>
+          </ul>
+        </div>
+        <form action="{{url_for('after')}}" class="form-inline" method="get" role="form">
+          <input class="col-6 form-control" type="month" name="target" min="2001-08" max="{{ now.strftime('%Y-%m') }}" value="{{ target.strftime('%Y-%m') }}">
+          <input class="btn btn-default" name="submit" type="submit" value="表示">
+        </form>
+        {% endif %}
       </div>
+      {% if request.args.get('submit') == '検索' %}
       <div class="row row-eq-height">
         {% for after in afters.items %}
         <div class="col-xs-12 col-sm-6">
           {{ macro.after(after, current_user) }}
         </div>
         {% endfor %}
+        <div class="text-center">
+          {{ pagination.info }}
+          {{ pagination.links }}
+        </div>
       </div>
-      <div class="text-center">
-        {{ pagination.links }}
+      {% else %}
+      <div class="row row-eq-height">
+        {% for after in afters %}
+        <div class="col-xs-12 col-sm-6">
+          {{ macro.after(after, current_user) }}
+        </div>
+        {% endfor %}
       </div>
+      <div class="bs-component">
+        <ul class="pager">
+          <li class="previous {{ "disabled" if target >= now}}"><a href="{{url_for('after', target=next.strftime('%Y-%m')) }}">&larr; 翌月</a></li>
+          <li>{{ target.year }}年{{ target.month }}月</li>
+          <li class="next {{ "disabled" if target.strftime('%Y-%m') <= "2001-08"}}"><a href="{{url_for('after', target=previous.strftime('%Y-%m')) }}" disa>前月 &rarr;</a></li>
+        </ul>
+      </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/templates/training.html
+++ b/templates/training.html
@@ -32,11 +32,26 @@
           <a href="{{url_for('training_edit')}}" class="btn btn-primary">新規登録</a>
           {% endif %}
         </h1>
+        {% if request.args.get('submit') == '検索' %}
         <div class="text-center">
           {{ pagination.info }}
           {{ pagination.links }}
         </div>
+        {% else %}
+        <div class="bs-component">
+          <ul class="pager">
+            <li class="previous {{ "disabled" if target >= now}}"><a href="{{url_for('training', target=next.strftime('%Y-%m')) }}">&larr; 翌月</a></li>
+            <li>{{ target.year }}年{{ target.month }}月</li>
+            <li class="next {{ "disabled" if target.strftime('%Y-%m') <= "2001-11"}}"><a href="{{url_for('training', target=previous.strftime('%Y-%m')) }}" disa>前月 &rarr;</a></li>
+          </ul>
+        </div>
+        <form action="{{url_for('training')}}" class="form-inline" method="get" role="form">
+          <input class="col-6 form-control" type="month" name="target" min="2001-11" max="{{ now.strftime('%Y-%m') }}" value="{{ target.strftime('%Y-%m') }}">
+          <input class="btn btn-default" name="submit" type="submit" value="表示">
+        </form>
+        {% endif %}
       </div>
+      {% if request.args.get('submit') == '検索' %}
       <div class="row row-eq-height">
         {% for training in trainings.items %}
         <div class="col-xs-12 col-sm-6">
@@ -45,9 +60,27 @@
         {% endfor %}
       </div>
       <div class="text-center">
+        {{ pagination.info }}
         {{ pagination.links }}
       </div>
+      {% else %}
+      <div class="row row-eq-height">
+        {% for training in trainings %}
+        <div class="col-xs-12 col-sm-6">
+          {{macro.training(training, current_user)}}
+        </div>
+        {% endfor %}
+      </div>
+      <div class="bs-component">
+        <ul class="pager">
+          <li class="previous {{ "disabled" if target >= now}}"><a href="{{url_for('training', target=next.strftime('%Y-%m')) }}">&larr; 翌月</a></li>
+          <li>{{ target.year }}年{{ target.month }}月</li>
+          <li class="next {{ "disabled" if target.strftime('%Y-%m') <= "2001-11"}}"><a href="{{url_for('training', target=previous.strftime('%Y-%m')) }}" disa>前月 &rarr;</a></li>
+        </ul>
+      </div>
+      {% endif %}
     </div>
   </div>
+</div>
 </div>
 {% endblock %}


### PR DESCRIPTION
デフォルトでは今月を表示、前月/翌月ボタン or `<input type="month">`での月選択で移動可能
検索結果は今まで通りページネーションで表示